### PR TITLE
modified abemafresh.tv to freshlive.tv

### DIFF
--- a/src/public/js/components/freshsetting.tsx
+++ b/src/public/js/components/freshsetting.tsx
@@ -18,7 +18,7 @@ export default function FreshSetting(
     return (
         <div className="row">
             <label className="col-xs-4 form-control-static text-xs-right">
-                FRESH! by AbemaTV:
+                FRESH!:
             </label>
             <span className="col-xs-4">
                 <TextBoxWithUpdateButton

--- a/src/public/js/models/freshwatcher.ts
+++ b/src/public/js/models/freshwatcher.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { Watcher } from "./watcher.ts";
 
-export default class AbemaWatcher extends EventEmitter implements Watcher {
+export default class FreshWatcher extends EventEmitter implements Watcher {
     private latestMillisecond = -1;
     private timer: NodeJS.Timer;
 
@@ -10,7 +10,7 @@ export default class AbemaWatcher extends EventEmitter implements Watcher {
         if (!isNaN(maybeProgramId)) {
             return maybeProgramId;
         }
-        let m = /https:\/\/abemafresh.tv\/.+\/([0-9]+)/
+        let m = /https:\/\/freshlive.tv\/.+\/([0-9]+)/
             .exec(urlOrProgramId);
         if (m == null) {
             return null;
@@ -56,7 +56,7 @@ export default class AbemaWatcher extends EventEmitter implements Watcher {
 
 async function getComments(programId: number) {
     let res = await fetch(
-        `https://abemafresh.tv/proxy/Comment;`
+        `https://freshlive.tv/proxy/Comment;`
         + `count=50;`
         + `order=desc;`
         + `programId=${programId}`);


### PR DESCRIPTION
Hi, I'm a developer of [FRESH!](https://freshlive.tv/). This tool is very cool!

Few days ago, we have changed domain of FRESH!. New domain is `freshlive.tv` . 
And also, we renamed `FRESH! by AbemaTV` to `FRESH!`. This PR is for that reason.